### PR TITLE
19: Fix site-deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ jdk:
 script: 
   - mvn -P release-profile clean install
 
-# https://docs.travis-ci.com/user/deployment/pages/
 deploy:
   provider: script
   skip_cleanup: true

--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 
 Inspired by [jcommander](https://github.com/cbeust/jcommander), this library provides simple and intuitive *injection* of configurations into object attributes of your choosing. It is intended for use in non-managed environments or projects where [JSR 299: Contexts and Dependency Injection for the JavaTM EE platform](https://jcp.org/en/jsr/detail?id=299) would be overkill.
 
-[Project site.](http://llorllale.github.io/jconfigurations)
+[Project site.](http://llorllale.github.io/jconfigurations/)
 
 Icon made by [EpiCoders](https://www.flaticon.com/authors/epiccoders) from [www.flaticon.com](https://www.flaticon.com).

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
         <version>3.3</version>
+        <configuration>
+          <skipDeploy>true</skipDeploy>
+        </configuration>
         <dependencies>
           <dependency>
             <groupId>lt.velykis.maven.skins</groupId>
@@ -187,7 +190,7 @@
       <plugin>
         <groupId>com.github.github</groupId>
         <artifactId>site-maven-plugin</artifactId>
-        <version>0.9</version>
+        <version>0.12</version>
         <executions>
           <execution>
             <goals>
@@ -195,7 +198,7 @@
             </goals>
             <phase>site-deploy</phase>
             <configuration>
-              <server>github</server>
+              <server>github-pages</server>
               <message>Site for ${project.artifactId}-${project.version}.</message>
               <merge>false</merge>
             </configuration>

--- a/settings.xml
+++ b/settings.xml
@@ -3,7 +3,7 @@
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
   <servers>
     <server>
-      <id>github-site</id>
+      <id>github-pages</id>
       <password>${env.site-token}</password>
     </server>
     <server>


### PR DESCRIPTION
(FIX) Downgraded version of github:site-maven-plugin to 0.12 to fix an
      issue (https://github.com/github/maven-plugins/issues/105)
(FIX) Link to project site in README.md

closes #19 